### PR TITLE
Set `letterSpacing` to 0 for cursive writing systems

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Text.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Text.kt
@@ -22,7 +22,9 @@ import androidx.compose.material3.tokens.DefaultTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
@@ -37,6 +39,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.unit.sp
 
 /**
  * High level element that displays text and provides semantics / accessibility information.
@@ -108,7 +113,7 @@ fun Text(
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
     style: TextStyle = LocalTextStyle.current
 ) {
-
+    val fixedLetterSpacing = rememberFixedLetterSpacing(text, letterSpacing, style.letterSpacing)
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
             LocalContentColor.current
@@ -127,7 +132,7 @@ fun Text(
             fontFamily = fontFamily,
             textDecoration = textDecoration,
             fontStyle = fontStyle,
-            letterSpacing = letterSpacing
+            letterSpacing = fixedLetterSpacing
         ),
         onTextLayout,
         overflow,
@@ -254,6 +259,7 @@ fun Text(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = LocalTextStyle.current
 ) {
+    val fixedLetterSpacing = rememberFixedLetterSpacing(text.text, letterSpacing, style.letterSpacing)
     val textColor = color.takeOrElse {
         style.color.takeOrElse {
             LocalContentColor.current
@@ -272,7 +278,7 @@ fun Text(
             fontFamily = fontFamily,
             textDecoration = textDecoration,
             fontStyle = fontStyle,
-            letterSpacing = letterSpacing
+            letterSpacing = fixedLetterSpacing
         ),
         onTextLayout = onTextLayout,
         overflow = overflow,
@@ -350,4 +356,63 @@ val LocalTextStyle = compositionLocalOf(structuralEqualityPolicy()) { DefaultTex
 fun ProvideTextStyle(value: TextStyle, content: @Composable () -> Unit) {
     val mergedStyle = LocalTextStyle.current.merge(value)
     CompositionLocalProvider(LocalTextStyle provides mergedStyle, content = content)
+}
+
+/**
+ * Letter spacing doesn't play well with cursive writing systems, as it can break the connection
+ * between letters and make the text fragmented. A simple and performant solution to this problem is
+ * to find the first "letter" character in the text (using `isLetter()`) and set `letterSpacing` to
+ * 0 if that character belongs to a cursive writing system and `letterSpacing` is greater than 0.
+ */
+@Composable
+private fun rememberFixedLetterSpacing(
+    text: String,
+    letterSpacing: TextUnit,
+    styleLetterSpacing: TextUnit,
+) = remember(text, letterSpacing, styleLetterSpacing) {
+    when (letterSpacing.isSpecified) {
+        true -> {
+            when (letterSpacing.value == 0f) {
+                true -> letterSpacing
+                false -> if (text.isFirstLetterCursive()) 0f.sp else letterSpacing
+            }
+        }
+        false -> {
+            when (styleLetterSpacing.let { it.isUnspecified || it.value == 0f }) {
+                true -> TextUnit.Unspecified
+                false -> if (text.isFirstLetterCursive()) 0f.sp else styleLetterSpacing
+            }
+        }
+    }
+}
+
+/**
+ * Returns **`true`** if the first letter of the string belongs to a cursive writing system. A good
+ * example is the Persian language. Letter spacing doesn't play well with cursive writing systems,
+ * as it can break the connection between letters and make the text fragmented.
+ */
+@Stable
+private fun String.isFirstLetterCursive(): Boolean {
+    for (char in this) {
+        if (!char.isLetter()) continue
+        val c = char.code
+        if (c < 1536) return false
+        if (c < 1920) return true
+        if (c < 1984) return false
+        if (c < 2048) return true
+        if (c < 2144) return false
+        if (c < 2304) return true
+        if (c < 4096) return false
+        if (c < 4256) return true
+        if (c < 43488) return false
+        if (c < 43520) return true
+        if (c < 43616) return false
+        if (c < 43648) return true
+        if (c < 64336) return false
+        if (c < 65024) return true
+        if (c < 65136) return false
+        if (c < 65280) return true
+        return false
+    }
+    return false
 }


### PR DESCRIPTION
Letter spacing doesn't play well with cursive writing systems, as it can break the connection between letters and make the text fragmented. To solve this problem, I propose checking the first "letter" character in the text using `isLetter()`. If it belongs to a cursive writing system (Persian and Arabic to name a few) and `letterSpacing` is greater than 0, set `letterSpacing` to `0.sp`. However, I agree that it feels "hacky" and better fixes can be applied at lower levels. I just wanted to share my solution to this.

### An example of how the text is fragmented

+ This is a **"Hello World"** in Persian:
**سلام دنیا**

+ This is how it looks like when space is added between the letters (Which looks broken/odd in a cursive writing system):
**سـ  ـلـ  ـا  م ‌  د  نـ  ـیـ  ـا**
